### PR TITLE
Fixing Readme's Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ corpus = sc.textFile('enwiki').map(lambda s: s.split())
 def gradient(model, sentences):  # executes on workers
     syn0, syn1 = model.syn0.copy(), model.syn1.copy()
     model.train(sentences)
-    return {'syn0': model.syn0 - syn01, 'syn1': model.syn1 - syn1}
+    return {'syn0': model.syn0 - syn0, 'syn1': model.syn1 - syn1}
 
 def descent(model, update):      # executes on master
     model.syn0 += update['syn0']


### PR DESCRIPTION
Fixing:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 599, in process_request_thread
Exception happened during processing of request from ('127.0.0.1', 54291)
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 599, in process_request_thread
: An error occurred while calling o38.collect.
: org.apache.spark.SparkException: Job aborted due to stage failure: Task 2 in stage 1.0 failed 1 times, most recent failure: Lost task 2.0 in stage 1.0 (TID 18, localhost): org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/Users/dav009/Downloads/spark-1.2.0-bin-hadoop2.4/python/pyspark/worker.py", line 107, in main
    process()
  File "/Users/dav009/Downloads/spark-1.2.0-bin-hadoop2.4/python/pyspark/worker.py", line 98, in process
    serializer.dump_stream(func(split_index, iterator), outfile)
  File "/Users/dav009/Downloads/spark-1.2.0-bin-hadoop2.4/python/pyspark/rdd.py", line 2073, in pipeline_func
    return func(split, prev_func(split, iterator))
  File "/Users/dav009/Downloads/spark-1.2.0-bin-hadoop2.4/python/pyspark/rdd.py", line 247, in func
    return f(iterator)
  File "/Library/Python/2.7/site-packages/deepdist-0.1-py2.7.egg/deepdist/deepdist.py", line 113, in mapPartitions
    return [send_gradient(gradient(fetch_model(master=master), data), master=master)]
  File "/Users/dav009/Documents/playing/test_deep.py", line 16, in gradient
    return {'syn0': model.syn0 - syn01, 'syn1': model.syn1 - syn1}
NameError: global name 'syn01' is not defined
```
